### PR TITLE
refactor: set network on client instantiation

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,1 @@
+export type allowedNetworks = "polygon" | "mumbai";


### PR DESCRIPTION
Not setting the network on instatiation of the client means the user will have to mention the network upon each method call.