### PR TITLE
refactor: no need for address in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Instantiate the Toucan client to interact with our infrastructure.
 ```typescript
 import ToucanClient from "toucan-sdk";
 
-const toucan = new ToucanClient("polygon", signer.address, provider, signer);
+const toucan = new ToucanClient("polygon", provider, signer);
 ```
 
 ## Fetch pool prices from SushiSwap

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import {
   IToucanPoolToken,
   OffsetHelper,
 } from "./typechain";
-import { Network, poolSymbol, providerish, signerish } from "./types";
+import { Network, poolSymbol } from "./types";
 import {
   fetchAggregationsMethod,
   fetchAllTCO2TokensMethod,
@@ -44,9 +44,8 @@ import addresses, { IfcOneNetworksAddresses } from "./utils/addresses";
 import { MUMBAI_GRAPH_API_URL, POLYGON_GRAPH_API_URL } from "./utils/graphAPIs";
 
 class ToucanClient {
-  provider: providerish;
-  signer: signerish;
-  walletAddress: string;
+  provider: ethers.providers.Provider;
+  signer: ethers.Wallet | ethers.Signer;
   network: Network;
   addresses: IfcOneNetworksAddresses;
   offsetHelper: OffsetHelper;
@@ -59,18 +58,15 @@ class ToucanClient {
   /**
    *
    * @param network network that you want to work on
-   * @param walletAddress address of the signer you want to use
    * @param provider web3 or jsonRpc provider
    * @param signer signer
    */
   constructor(
     network: Network,
-    walletAddress: string,
-    provider: providerish,
-    signer: signerish
+    provider: ethers.providers.Provider,
+    signer: ethers.Wallet | ethers.Signer
   ) {
     this.network = network;
-    this.walletAddress = walletAddress;
     this.provider = provider;
     this.signer = signer;
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -21,7 +21,7 @@ describe("Testing Toucan-SDK", function () {
 
   before(async () => {
     [addr1, addr2, ...addrs] = await ethers.getSigners();
-    toucan = new ToucanClient("polygon", addr1.address, ethers.provider, addr1);
+    toucan = new ToucanClient("polygon", ethers.provider, addr1);
 
     swapper = new ethers.Contract(addresses.polygon.swapper, swapperABI, addr1);
     await swapper.swap(addresses.polygon.nct, parseEther("100.0"), {
@@ -260,12 +260,7 @@ describe("Testing Toucan-SDK", function () {
       toucan.instantiateTCO2(tco2s[0].address);
       await toucan.TCO2?.approve(addr2.address, parseEther("1.0"));
 
-      const toucan2 = new ToucanClient(
-        "polygon",
-        addr2.address,
-        ethers.provider,
-        addr2
-      );
+      const toucan2 = new ToucanClient("polygon", ethers.provider, addr2);
       toucan2.instantiateTCO2(tco2s[0].address);
       await expect(toucan2.retireFrom(parseEther("1.0"), addr1.address)).to.not
         .be.reverted;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,12 +1,4 @@
-import { ethers } from "ethers";
-
 export type Network = "polygon" | "mumbai";
-
-export type providerish =
-  | ethers.providers.Web3Provider
-  | ethers.providers.JsonRpcProvider;
-
-export type signerish = ethers.providers.Provider | ethers.Signer;
 
 export type poolSymbol = "BCT" | "NCT";
 


### PR DESCRIPTION
We couldn't remove the need for the user to provide his signer's address until now because we were using wrong types in `singerish`.

With that fixed, we can now fetch the signer's address with `await this.signer.getAddress();`.