### PR TITLE
PRT-277-toucan-sdk-release-failed-to-npm-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2-alpha",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
The [publish CI failed here](https://github.com/ToucanProtocol/toucan-sdk/runs/6934191391?check_suite_focus=true), and after taking a closer look it's because I haven't updated the package version to [match the release](https://github.com/ToucanProtocol/toucan-sdk/releases/tag/v0.1.2-alpha). 

Merging this and re-running the CI should publish the SDK to npm just fine.