### PR TITLE
PRT-300 Update TS config to not mention HH config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "0.1.3-beta",
+  "version": "0.1.4-beta",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "index.ts",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,5 @@
     "outDir": "dist",
     "declaration": true
   },
-  "include": ["./**/*.ts", "./**.ts"],
-  "files": ["./hardhat.config.ts"]
+  "include": ["./**/*.ts", "./**.ts"]
 }


### PR DESCRIPTION
HH.config being a devDependency, it will not be found in the node module once the SDK is published. This causes bugs for the user because TS config specifically mentions the HH config file. I fixed the TS config and need to re-release the SDK.

Thanks @Niwilai  for figuring this out 🙏🏻