### PR TITLE
PRT-305: Disable dev dependency dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-name: "*"
+      dependency-type: "production"


### PR DESCRIPTION
@kargakis made a point to not have devDependancies updated by the bot