### PR TITLE
PRT-305: disable dev dependency dependabot fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "*"
-      dependency-type: "production"
+        dependency-type: "production"


### PR DESCRIPTION
In #34 I pushed a `dependabot.yml` modification that was supposed to have dependabot only update normal dependancies and not devDependancies.

That didn't turn out well because I wrote bad yml syntax when following the [docs here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) which resulted into a build/dependabot error that we could only see after the merge.

That's because dependabot doesn't run on merge.