### PR TITLE
[PROD-2028] Fix & improve SDK tests 

### DIFF
--- a/src/utils/ABIs.ts
+++ b/src/utils/ABIs.ts
@@ -1,4 +1,18 @@
 export const poolTokenABI = [
+  { inputs: [], stateMutability: "nonpayable", type: "constructor" },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "tco2",
+        type: "address",
+      },
+    ],
+    name: "AddFeeExemptedTCO2",
+    type: "event",
+  },
   {
     anonymous: false,
     inputs: [
@@ -182,6 +196,14 @@ export const poolTokenABI = [
   {
     anonymous: false,
     inputs: [
+      { indexed: false, internalType: "uint8", name: "version", type: "uint8" },
+    ],
+    name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
       {
         indexed: false,
         internalType: "address",
@@ -351,6 +373,19 @@ export const poolTokenABI = [
       },
     ],
     name: "Redeemed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "tco2",
+        type: "address",
+      },
+    ],
+    name: "RemoveFeeExemptedTCO2",
     type: "event",
   },
   {
@@ -534,6 +569,13 @@ export const poolTokenABI = [
     type: "function",
   },
   {
+    inputs: [{ internalType: "address", name: "_tco2", type: "address" }],
+    name: "addRedeemFeeExemptedTCO2",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [
       { internalType: "address[]", name: "erc20Addr", type: "address[]" },
     ],
@@ -585,6 +627,26 @@ export const poolTokenABI = [
     name: "balanceOf",
     outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "_account", type: "address" },
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+    ],
+    name: "bridgeBurn",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "_account", type: "address" },
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+    ],
+    name: "bridgeMint",
+    outputs: [],
+    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -809,6 +871,23 @@ export const poolTokenABI = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "tco2", type: "address" },
+      { internalType: "uint256", name: "amount", type: "uint256" },
+    ],
+    name: "redeemAndBurn",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [{ internalType: "uint256", name: "amount", type: "uint256" }],
     name: "redeemAuto",
     outputs: [],
@@ -833,8 +912,15 @@ export const poolTokenABI = [
     type: "function",
   },
   {
+    inputs: [{ internalType: "address", name: "", type: "address" }],
+    name: "redeemFeeExemptedTCO2s",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [
-      { internalType: "address[]", name: "erc20s", type: "address[]" },
+      { internalType: "address[]", name: "tco2s", type: "address[]" },
       { internalType: "uint256[]", name: "amounts", type: "uint256[]" },
     ],
     name: "redeemMany",
@@ -891,6 +977,13 @@ export const poolTokenABI = [
     type: "function",
   },
   {
+    inputs: [{ internalType: "address", name: "_tco2", type: "address" }],
+    name: "removeRedeemFeeExemptedTCO2",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [],
     name: "renounceOwnership",
     outputs: [],
@@ -918,9 +1011,23 @@ export const poolTokenABI = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "router",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
     name: "scoredTCO2s",
     outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "seedMode",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
     stateMutability: "view",
     type: "function",
   },
@@ -981,6 +1088,13 @@ export const poolTokenABI = [
       },
     ],
     name: "setMinimumVintageStartTime",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "_router", type: "address" }],
+    name: "setRouter",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -1148,7 +1262,12 @@ export const offsetHelperABI = [
   {
     anonymous: false,
     inputs: [
-      { indexed: false, internalType: "uint8", name: "version", type: "uint8" },
+      {
+        indexed: false,
+        internalType: "uint8",
+        name: "version",
+        type: "uint8",
+      },
     ],
     name: "Initialized",
     type: "event",
@@ -1175,7 +1294,12 @@ export const offsetHelperABI = [
   {
     anonymous: false,
     inputs: [
-      { indexed: false, internalType: "address", name: "who", type: "address" },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "who",
+        type: "address",
+      },
       {
         indexed: false,
         internalType: "address",
@@ -1198,64 +1322,143 @@ export const offsetHelperABI = [
     name: "Redeemed",
     type: "event",
   },
-  { stateMutability: "payable", type: "fallback" },
+  {
+    stateMutability: "payable",
+    type: "fallback",
+  },
   {
     inputs: [
-      { internalType: "address", name: "_poolToken", type: "address" },
-      { internalType: "uint256", name: "_amountToOffset", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amountToOffset",
+        type: "uint256",
+      },
     ],
     name: "autoOffsetUsingETH",
     outputs: [
-      { internalType: "address[]", name: "tco2s", type: "address[]" },
-      { internalType: "uint256[]", name: "amounts", type: "uint256[]" },
+      {
+        internalType: "address[]",
+        name: "tco2s",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "amounts",
+        type: "uint256[]",
+      },
     ],
     stateMutability: "payable",
     type: "function",
   },
   {
     inputs: [
-      { internalType: "address", name: "_poolToken", type: "address" },
-      { internalType: "uint256", name: "_amountToOffset", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amountToOffset",
+        type: "uint256",
+      },
     ],
     name: "autoOffsetUsingPoolToken",
     outputs: [
-      { internalType: "address[]", name: "tco2s", type: "address[]" },
-      { internalType: "uint256[]", name: "amounts", type: "uint256[]" },
+      {
+        internalType: "address[]",
+        name: "tco2s",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "amounts",
+        type: "uint256[]",
+      },
     ],
     stateMutability: "nonpayable",
     type: "function",
   },
   {
     inputs: [
-      { internalType: "address", name: "_depositedToken", type: "address" },
-      { internalType: "address", name: "_poolToken", type: "address" },
-      { internalType: "uint256", name: "_amountToOffset", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_depositedToken",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amountToOffset",
+        type: "uint256",
+      },
     ],
     name: "autoOffsetUsingToken",
     outputs: [
-      { internalType: "address[]", name: "tco2s", type: "address[]" },
-      { internalType: "uint256[]", name: "amounts", type: "uint256[]" },
+      {
+        internalType: "address[]",
+        name: "tco2s",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "amounts",
+        type: "uint256[]",
+      },
     ],
     stateMutability: "nonpayable",
     type: "function",
   },
   {
     inputs: [
-      { internalType: "address", name: "_fromToken", type: "address" },
-      { internalType: "uint256", name: "_amount", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_fromToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
     ],
     name: "autoRedeem",
     outputs: [
-      { internalType: "address[]", name: "tco2s", type: "address[]" },
-      { internalType: "uint256[]", name: "amounts", type: "uint256[]" },
+      {
+        internalType: "address[]",
+        name: "tco2s",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "amounts",
+        type: "uint256[]",
+      },
     ],
     stateMutability: "nonpayable",
     type: "function",
   },
   {
     inputs: [
-      { internalType: "address[]", name: "_tco2s", type: "address[]" },
-      { internalType: "uint256[]", name: "_amounts", type: "uint256[]" },
+      {
+        internalType: "address[]",
+        name: "_tco2s",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "_amounts",
+        type: "uint256[]",
+      },
     ],
     name: "autoRetire",
     outputs: [],
@@ -1264,44 +1467,102 @@ export const offsetHelperABI = [
   },
   {
     inputs: [
-      { internalType: "address", name: "", type: "address" },
-      { internalType: "address", name: "", type: "address" },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
     ],
     name: "balances",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
     stateMutability: "view",
     type: "function",
   },
   {
     inputs: [
-      { internalType: "address", name: "_toToken", type: "address" },
-      { internalType: "uint256", name: "_amount", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_toToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
     ],
     name: "calculateNeededETHAmount",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
     stateMutability: "view",
     type: "function",
   },
   {
     inputs: [
-      { internalType: "address", name: "_fromToken", type: "address" },
-      { internalType: "address", name: "_toToken", type: "address" },
-      { internalType: "uint256", name: "_amount", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_fromToken",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_toToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
     ],
     name: "calculateNeededTokenAmount",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
     stateMutability: "view",
     type: "function",
   },
   {
     inputs: [],
     name: "contractRegistryAddress",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
     stateMutability: "view",
     type: "function",
   },
   {
-    inputs: [{ internalType: "string", name: "_tokenSymbol", type: "string" }],
+    inputs: [
+      {
+        internalType: "string",
+        name: "_tokenSymbol",
+        type: "string",
+      },
+    ],
     name: "deleteEligibleTokenAddress",
     outputs: [],
     stateMutability: "nonpayable",
@@ -1309,8 +1570,16 @@ export const offsetHelperABI = [
   },
   {
     inputs: [
-      { internalType: "address", name: "_erc20Addr", type: "address" },
-      { internalType: "uint256", name: "_amount", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_erc20Addr",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
     ],
     name: "deposit",
     outputs: [],
@@ -1318,16 +1587,34 @@ export const offsetHelperABI = [
     type: "function",
   },
   {
-    inputs: [{ internalType: "string", name: "", type: "string" }],
+    inputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
     name: "eligibleTokenAddresses",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
     stateMutability: "view",
     type: "function",
   },
   {
     inputs: [],
     name: "owner",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
     stateMutability: "view",
     type: "function",
   },
@@ -1340,8 +1627,16 @@ export const offsetHelperABI = [
   },
   {
     inputs: [
-      { internalType: "string", name: "_tokenSymbol", type: "string" },
-      { internalType: "address", name: "_address", type: "address" },
+      {
+        internalType: "string",
+        name: "_tokenSymbol",
+        type: "string",
+      },
+      {
+        internalType: "address",
+        name: "_address",
+        type: "address",
+      },
     ],
     name: "setEligibleTokenAddress",
     outputs: [],
@@ -1349,7 +1644,13 @@ export const offsetHelperABI = [
     type: "function",
   },
   {
-    inputs: [{ internalType: "address", name: "_address", type: "address" }],
+    inputs: [
+      {
+        internalType: "address",
+        name: "_address",
+        type: "address",
+      },
+    ],
     name: "setToucanContractRegistry",
     outputs: [],
     stateMutability: "nonpayable",
@@ -1358,14 +1659,28 @@ export const offsetHelperABI = [
   {
     inputs: [],
     name: "sushiRouterAddress",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
     stateMutability: "view",
     type: "function",
   },
   {
     inputs: [
-      { internalType: "address", name: "_toToken", type: "address" },
-      { internalType: "uint256", name: "_amount", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_toToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
     ],
     name: "swap",
     outputs: [],
@@ -1374,9 +1689,21 @@ export const offsetHelperABI = [
   },
   {
     inputs: [
-      { internalType: "address", name: "_fromToken", type: "address" },
-      { internalType: "address", name: "_toToken", type: "address" },
-      { internalType: "uint256", name: "_amount", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_fromToken",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_toToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
     ],
     name: "swap",
     outputs: [],
@@ -1384,7 +1711,13 @@ export const offsetHelperABI = [
     type: "function",
   },
   {
-    inputs: [{ internalType: "address", name: "newOwner", type: "address" }],
+    inputs: [
+      {
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
     name: "transferOwnership",
     outputs: [],
     stateMutability: "nonpayable",
@@ -1392,15 +1725,26 @@ export const offsetHelperABI = [
   },
   {
     inputs: [
-      { internalType: "address", name: "_erc20Addr", type: "address" },
-      { internalType: "uint256", name: "_amount", type: "uint256" },
+      {
+        internalType: "address",
+        name: "_erc20Addr",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
     ],
     name: "withdraw",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
   },
-  { stateMutability: "payable", type: "receive" },
+  {
+    stateMutability: "payable",
+    type: "receive",
+  },
 ];
 
 export const swapperABI = [

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,12 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { Contract } from "ethers";
-import { FormatTypes, Interface, parseEther } from "ethers/lib/utils";
+import {
+  formatEther,
+  FormatTypes,
+  Interface,
+  parseEther,
+} from "ethers/lib/utils";
 import { ethers } from "hardhat";
 
 import { ToucanClient } from "../dist";
@@ -48,8 +53,7 @@ describe("Testing Toucan-SDK", function () {
 
   describe("Testing OffsetHelper related methods", function () {
     it("Should retire 1 TCO2 using pool token deposit", async function () {
-      await expect(toucan.autoOffsetUsingPoolToken("NCT", parseEther("1.0"))).to
-        .not.be.reverted;
+      await toucan.autoOffsetUsingPoolToken("NCT", parseEther("1.0"));
     });
 
     it("Should retire 1 TCO2 using swap token", async function () {
@@ -59,14 +63,11 @@ describe("Testing Toucan-SDK", function () {
       iface.format(FormatTypes.full);
       const weth = new ethers.Contract(addresses.polygon.weth, iface, addr1);
 
-      await expect(
-        toucan.autoOffsetUsingSwapToken("NCT", parseEther("1.0"), weth)
-      ).to.not.be.reverted;
+      await toucan.autoOffsetUsingSwapToken("NCT", parseEther("1.0"), weth);
     });
 
     it("Should retire 1 TCO2 using ETH deposit", async function () {
-      await expect(toucan.autoOffsetUsingETH("NCT", parseEther("1.0"))).to.not
-        .be.reverted;
+      await toucan.autoOffsetUsingETH("NCT", parseEther("1.0"));
     });
   });
 
@@ -79,11 +80,10 @@ describe("Testing Toucan-SDK", function () {
       );
       const nctBalanceBefore = await nct.balanceOf(addr1.address);
 
-      await expect(toucan.redeemAuto("NCT", parseEther("1.0"))).to.not.be
-        .reverted;
+      await toucan.redeemAuto("NCT", parseEther("1.0"));
 
-      expect(await nct.balanceOf(addr1.address)).to.be.eql(
-        nctBalanceBefore.sub(parseEther("1.0"))
+      expect(formatEther(await nct.balanceOf(addr1.address))).to.be.eql(
+        formatEther(nctBalanceBefore.sub(parseEther("1.0")))
       );
     });
 
@@ -95,8 +95,8 @@ describe("Testing Toucan-SDK", function () {
 
       for (let i = 0; i < tco2s.length; i++) {
         const tco2 = new ethers.Contract(tco2s[i].address, tco2ABI, addr1);
-        expect(await tco2.balanceOf(addr1.address)).to.be.eql(
-          (await tco2s[i].amount).add(balanceBefore)
+        expect(formatEther(await tco2.balanceOf(addr1.address))).to.be.eql(
+          formatEther((await tco2s[i].amount).add(balanceBefore))
         );
       }
     });
@@ -117,15 +117,16 @@ describe("Testing Toucan-SDK", function () {
         [parseEther("1.0")]
       );
 
-      await expect(toucan.redeemMany("NCT", [tco2Address], [parseEther("1.0")]))
-        .to.not.be.reverted;
+      await toucan.redeemMany("NCT", [tco2Address], [parseEther("1.0")]);
 
       const tco2 = new ethers.Contract(tco2Address, tco2ABI, addr1);
       const balance = await tco2.balanceOf(addr1.address);
-      expect(balance).to.be.eql(parseEther("1.0").sub(fees));
+      expect(formatEther(balance)).to.be.eql(
+        formatEther(parseEther("1.0").sub(fees))
+      );
 
-      expect(await nct.balanceOf(addr1.address)).to.be.eql(
-        nctBalanceBefore.sub(parseEther("1.0"))
+      expect(formatEther(await nct.balanceOf(addr1.address))).to.be.eql(
+        formatEther(nctBalanceBefore.sub(parseEther("1.0")))
       );
     });
 
@@ -145,12 +146,15 @@ describe("Testing Toucan-SDK", function () {
 
       await toucan.redeemAuto("NCT", parseEther("1.0"));
 
-      await expect(toucan.depositTCO2("NCT", parseEther("1.0"), tco2.address))
-        .to.not.be.reverted;
+      await toucan.depositTCO2("NCT", parseEther("1.0"), tco2.address);
 
-      expect(await tco2.balanceOf(addr1.address)).to.be.eql(tco2BalanceBefore);
+      expect(formatEther(await tco2.balanceOf(addr1.address))).to.be.eql(
+        formatEther(tco2BalanceBefore)
+      );
 
-      expect(await nct.balanceOf(addr1.address)).to.be.eql(nctBalanceBefore);
+      expect(formatEther(await nct.balanceOf(addr1.address))).to.be.eql(
+        formatEther(nctBalanceBefore)
+      );
     });
   });
 
@@ -171,15 +175,16 @@ describe("Testing Toucan-SDK", function () {
         [parseEther("1.0")]
       );
 
-      await expect(toucan.redeemMany("BCT", [tco2Address], [parseEther("1.0")]))
-        .to.not.be.reverted;
+      await toucan.redeemMany("BCT", [tco2Address], [parseEther("1.0")]);
 
       const tco2 = new ethers.Contract(tco2Address, tco2ABI, addr1);
       const balance = await tco2.balanceOf(addr1.address);
-      expect(balance).to.be.eql(parseEther("1.0").sub(fees));
+      expect(formatEther(balance)).to.be.eql(
+        formatEther(parseEther("1.0").sub(fees))
+      );
 
-      expect(await bct.balanceOf(addr1.address)).to.be.eql(
-        bctBalanceBefore.sub(parseEther("1.0"))
+      expect(formatEther(await bct.balanceOf(addr1.address))).to.be.eql(
+        formatEther(bctBalanceBefore.sub(parseEther("1.0")))
       );
     });
 
@@ -191,12 +196,15 @@ describe("Testing Toucan-SDK", function () {
 
       await toucan.redeemAuto("BCT", parseEther("1.0"));
 
-      await expect(toucan.depositTCO2("BCT", parseEther("1.0"), TCO2.address))
-        .to.not.be.reverted;
+      await toucan.depositTCO2("BCT", parseEther("1.0"), TCO2.address);
 
-      expect(await TCO2.balanceOf(addr1.address)).to.be.eql(tco2BalanceBefore);
+      expect(formatEther(await TCO2.balanceOf(addr1.address))).to.be.eql(
+        formatEther(tco2BalanceBefore)
+      );
 
-      expect(await bct.balanceOf(addr1.address)).to.be.eql(bctBalanceBefore);
+      expect(formatEther(await bct.balanceOf(addr1.address))).to.be.eql(
+        formatEther(bctBalanceBefore)
+      );
     });
   });
 
@@ -250,9 +258,7 @@ describe("Testing Toucan-SDK", function () {
       const toucan2 = new ToucanClient("polygon");
       toucan2.setSigner(addr2);
 
-      await expect(
-        toucan2.retireFrom(parseEther("1.0"), addr1.address, TCO2.address)
-      ).to.not.be.reverted;
+      await toucan2.retireFrom(parseEther("1.0"), addr1.address, TCO2.address);
     });
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,9 +10,8 @@ import {
 import { ethers } from "hardhat";
 
 import { ToucanClient } from "../dist";
-import { IToucanCarbonOffsets } from "../dist/typechain";
 import { PoolSymbol } from "../dist/types";
-import { poolTokenABI, swapperABI, tco2ABI } from "../dist/utils/ABIs";
+import { poolTokenABI, swapperABI } from "../dist/utils/ABIs";
 import addresses from "../dist/utils/addresses";
 
 const ONE_ETHER = parseEther("1.0");
@@ -46,6 +45,33 @@ describe("Testing Toucan-SDK contract interactions", function () {
     Promise.all(arr.map(predicate)).then((results) =>
       arr.filter((_el, index) => results[index])
     );
+
+  /**
+   *
+   * @description checks whether you can redeem 1 TCO2 and returns the amount of redeemable TCO2
+   * @dev this exists because when redeeming you might end up attempting to redeem more than the balance of the first
+   * scored TCO2 if using a hardcoded redeem amount
+   * @param poolSymbol pool to get dynamic redeem amount for
+   * @param tco2Quality quality of the TCO2 to redeem
+   * @returns BigNumber representing the amount of TCO2 you can redeem safely
+   */
+  const getDynamicRedeemAmount = async (
+    poolSymbol: PoolSymbol,
+    tco2Quality: "low" | "high"
+  ): Promise<{ tco2Address: string; amountToRedeem: BigNumber }> => {
+    const scoredTCO2s = await getFilteredScoredTCO2s(poolSymbol);
+    const tco2Address =
+      tco2Quality == "low"
+        ? scoredTCO2s[0]
+        : scoredTCO2s[scoredTCO2s.length - 1];
+    const tco2 = toucan.getTCO2Contract(tco2Address);
+    const pool = toucan.getPoolContract(poolSymbol);
+    const balance = (await tco2.balanceOf(pool.address)) as BigNumber;
+    return {
+      tco2Address,
+      amountToRedeem: balance.gt(ONE_ETHER) ? ONE_ETHER : balance,
+    };
+  };
 
   before(async () => {
     [addr1, addr2] = await ethers.getSigners();
@@ -110,19 +136,27 @@ describe("Testing Toucan-SDK contract interactions", function () {
     });
 
     it("Should automatically redeem NCT & return a correct array of TCO2s", async function () {
-      const scoredTCO2s = await getFilteredScoredTCO2s("NCT");
+      const { tco2Address, amountToRedeem } = await getDynamicRedeemAmount(
+        "NCT",
+        "low"
+      );
 
       const expectedTco2s: {
         address: string;
         amount: BigNumber;
-      }[] = [{ address: scoredTCO2s[0], amount: ONE_ETHER }];
+      }[] = [{ address: tco2Address, amount: amountToRedeem }];
 
-      const tco2s = await toucan.redeemAuto2("NCT", ONE_ETHER);
+      const tco2s = await toucan.redeemAuto2("NCT", amountToRedeem);
 
       expect(tco2s).to.be.eql(expectedTco2s);
     });
 
     it("Should selectively redeem NCT for the highest quality TCO2s", async function () {
+      const { tco2Address, amountToRedeem } = await getDynamicRedeemAmount(
+        "NCT",
+        "high"
+      );
+
       const nct = new ethers.Contract(
         addresses.polygon.nct,
         poolTokenABI,
@@ -130,50 +164,43 @@ describe("Testing Toucan-SDK contract interactions", function () {
       );
       const nctBalanceBefore = await nct.balanceOf(addr1.address);
 
-      const scoredTCO2sNCT = await getFilteredScoredTCO2s("NCT");
-
-      const tco2Address = scoredTCO2sNCT[scoredTCO2sNCT.length - 1];
+      const tco2 = toucan.getTCO2Contract(tco2Address);
 
       const fees = await toucan.calculateRedeemFees(
         "NCT",
         [tco2Address],
-        [ONE_ETHER]
+        [amountToRedeem]
       );
+      await toucan.redeemMany("NCT", [tco2Address], [amountToRedeem]);
 
-      await toucan.redeemMany("NCT", [tco2Address], [ONE_ETHER]);
-
-      const tco2 = new ethers.Contract(tco2Address, tco2ABI, addr1);
       const balance = await tco2.balanceOf(addr1.address);
-      expect(formatEther(balance)).to.be.eql(formatEther(ONE_ETHER.sub(fees)));
 
+      expect(formatEther(balance)).to.be.eql(
+        formatEther(amountToRedeem.sub(fees))
+      );
       expect(formatEther(await nct.balanceOf(addr1.address))).to.be.eql(
-        formatEther(nctBalanceBefore.sub(ONE_ETHER))
+        formatEther(nctBalanceBefore.sub(amountToRedeem))
       );
     });
 
     it("Should automatically redeem NCT & deposit the TCO2 back", async function () {
-      const scoredTCO2s = await getFilteredScoredTCO2s("NCT");
-      const tco2 = new ethers.Contract(
-        scoredTCO2s[0],
-        tco2ABI,
-        addr1
-      ) as IToucanCarbonOffsets;
-      const tco2BalanceBefore = await tco2.balanceOf(addr1.address);
-      const nct = new ethers.Contract(
-        addresses.polygon.nct,
-        poolTokenABI,
-        addr1
+      const { tco2Address, amountToRedeem } = await getDynamicRedeemAmount(
+        "NCT",
+        "low"
       );
+
+      const nct = toucan.getPoolContract("NCT");
+      const tco2 = toucan.getTCO2Contract(tco2Address);
+
+      const tco2BalanceBefore = await tco2.balanceOf(addr1.address);
       const nctBalanceBefore = await nct.balanceOf(addr1.address);
 
-      await toucan.redeemAuto("NCT", ONE_ETHER);
-
-      await toucan.depositTCO2("NCT", ONE_ETHER, tco2.address);
+      await toucan.redeemAuto("NCT", amountToRedeem);
+      await toucan.depositTCO2("NCT", amountToRedeem, tco2.address);
 
       expect(formatEther(await tco2.balanceOf(addr1.address))).to.be.eql(
         formatEther(tco2BalanceBefore)
       );
-
       expect(formatEther(await nct.balanceOf(addr1.address))).to.be.eql(
         formatEther(nctBalanceBefore)
       );
@@ -182,49 +209,54 @@ describe("Testing Toucan-SDK contract interactions", function () {
 
   describe("Testing BCT related methods", function () {
     it("Should selectively redeem BCT for the highest quality TCO2s", async function () {
+      const { tco2Address, amountToRedeem } = await getDynamicRedeemAmount(
+        "BCT",
+        "high"
+      );
+
       const bct = new ethers.Contract(
         addresses.polygon.bct,
         poolTokenABI,
         addr1
       );
       const bctBalanceBefore = await bct.balanceOf(addr1.address);
-
-      const scoredTCO2sBCT = await getFilteredScoredTCO2s("BCT");
-
-      const tco2Address = scoredTCO2sBCT[scoredTCO2sBCT.length - 1];
+      const tco2 = toucan.getTCO2Contract(tco2Address);
 
       const fees = await toucan.calculateRedeemFees(
         "BCT",
         [tco2Address],
-        [ONE_ETHER]
+        [amountToRedeem]
       );
+      await toucan.redeemMany("BCT", [tco2Address], [amountToRedeem]);
 
-      await toucan.redeemMany("BCT", [tco2Address], [ONE_ETHER]);
-
-      const tco2 = new ethers.Contract(tco2Address, tco2ABI, addr1);
       const balance = await tco2.balanceOf(addr1.address);
-      expect(formatEther(balance)).to.be.eql(formatEther(ONE_ETHER.sub(fees)));
 
+      expect(formatEther(balance)).to.be.eql(
+        formatEther(amountToRedeem.sub(fees))
+      );
       expect(formatEther(await bct.balanceOf(addr1.address))).to.be.eql(
-        formatEther(bctBalanceBefore.sub(ONE_ETHER))
+        formatEther(bctBalanceBefore.sub(amountToRedeem))
       );
     });
 
     it("Should automatically redeem BCT & deposit the TCO2 back", async function () {
-      const scoredTCO2s = await getFilteredScoredTCO2s("BCT");
-      const TCO2 = toucan.getTCO2Contract(scoredTCO2s[0]);
-      const tco2BalanceBefore = await TCO2.balanceOf(addr1.address);
-      const bct = toucan.getPoolContract("BCT");
-      const bctBalanceBefore = await bct.balanceOf(addr1.address);
-
-      await toucan.redeemAuto("BCT", ONE_ETHER);
-
-      await toucan.depositTCO2("BCT", ONE_ETHER, TCO2.address);
-
-      expect(formatEther(await TCO2.balanceOf(addr1.address))).to.be.eql(
-        formatEther(tco2BalanceBefore)
+      const { tco2Address, amountToRedeem } = await getDynamicRedeemAmount(
+        "BCT",
+        "low"
       );
 
+      const bct = toucan.getPoolContract("BCT");
+      const tco2 = toucan.getTCO2Contract(tco2Address);
+
+      const tco2BalanceBefore = await tco2.balanceOf(addr1.address);
+      const bctBalanceBefore = await bct.balanceOf(addr1.address);
+
+      await toucan.redeemAuto("BCT", amountToRedeem);
+      await toucan.depositTCO2("BCT", amountToRedeem, tco2.address);
+
+      expect(formatEther(await tco2.balanceOf(addr1.address))).to.be.eql(
+        formatEther(tco2BalanceBefore)
+      );
       expect(formatEther(await bct.balanceOf(addr1.address))).to.be.eql(
         formatEther(bctBalanceBefore)
       );

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
-import { BigNumber, constants, Contract } from "ethers";
+import { BigNumber, Contract } from "ethers";
 import {
   formatEther,
   FormatTypes,
@@ -14,6 +14,8 @@ import { IToucanCarbonOffsets } from "../dist/typechain";
 import { PoolSymbol } from "../dist/types";
 import { poolTokenABI, swapperABI, tco2ABI } from "../dist/utils/ABIs";
 import addresses from "../dist/utils/addresses";
+
+const ONE_ETHER = parseEther("1.0");
 
 describe("Testing Toucan-SDK contract interactions", function () {
   let addr1: SignerWithAddress;
@@ -33,7 +35,7 @@ describe("Testing Toucan-SDK contract interactions", function () {
     const pool = toucan.getPoolContract(poolSymbol);
     return await asyncFilter(scoredTCO2s, async (tco2Address: string) => {
       const tokenBalance: BigNumber = await pool["tokenBalances"](tco2Address);
-      return tokenBalance.gt(constants.Zero);
+      return tokenBalance.gt(parseEther("0.0"));
     });
   };
 
@@ -63,17 +65,17 @@ describe("Testing Toucan-SDK contract interactions", function () {
         parseEther("100.0")
       ),
     });
-    await swapper.swap(addresses.polygon.weth, parseEther("1.0"), {
+    await swapper.swap(addresses.polygon.weth, ONE_ETHER, {
       value: await swapper.calculateNeededETHAmount(
         addresses.polygon.weth,
-        parseEther("1.0")
+        ONE_ETHER
       ),
     });
   });
 
   describe("Testing OffsetHelper related methods", function () {
     it("Should retire 1 TCO2 using pool token deposit", async function () {
-      await toucan.autoOffsetUsingPoolToken("NCT", parseEther("1.0"));
+      await toucan.autoOffsetUsingPoolToken("NCT", ONE_ETHER);
     });
 
     it("Should retire 1 TCO2 using swap token", async function () {
@@ -83,11 +85,11 @@ describe("Testing Toucan-SDK contract interactions", function () {
       iface.format(FormatTypes.full);
       const weth = new ethers.Contract(addresses.polygon.weth, iface, addr1);
 
-      await toucan.autoOffsetUsingSwapToken("NCT", parseEther("1.0"), weth);
+      await toucan.autoOffsetUsingSwapToken("NCT", ONE_ETHER, weth);
     });
 
     it("Should retire 1 TCO2 using ETH deposit", async function () {
-      await toucan.autoOffsetUsingETH("NCT", parseEther("1.0"));
+      await toucan.autoOffsetUsingETH("NCT", ONE_ETHER);
     });
   });
 
@@ -100,10 +102,10 @@ describe("Testing Toucan-SDK contract interactions", function () {
       );
       const nctBalanceBefore = await nct.balanceOf(addr1.address);
 
-      await toucan.redeemAuto("NCT", parseEther("1.0"));
+      await toucan.redeemAuto("NCT", ONE_ETHER);
 
       expect(formatEther(await nct.balanceOf(addr1.address))).to.be.eql(
-        formatEther(nctBalanceBefore.sub(parseEther("1.0")))
+        formatEther(nctBalanceBefore.sub(ONE_ETHER))
       );
     });
 
@@ -112,7 +114,7 @@ describe("Testing Toucan-SDK contract interactions", function () {
       const tco2 = new ethers.Contract(scoredTCO2s[0], tco2ABI, addr1);
       const balanceBefore = await tco2.balanceOf(addr1.address);
 
-      const tco2s = await toucan.redeemAuto2("NCT", parseEther("1.0"));
+      const tco2s = await toucan.redeemAuto2("NCT", ONE_ETHER);
 
       for (let i = 0; i < tco2s.length; i++) {
         const tco2 = new ethers.Contract(tco2s[i].address, tco2ABI, addr1);
@@ -137,19 +139,17 @@ describe("Testing Toucan-SDK contract interactions", function () {
       const fees = await toucan.calculateRedeemFees(
         "NCT",
         [tco2Address],
-        [parseEther("1.0")]
+        [ONE_ETHER]
       );
 
-      await toucan.redeemMany("NCT", [tco2Address], [parseEther("1.0")]);
+      await toucan.redeemMany("NCT", [tco2Address], [ONE_ETHER]);
 
       const tco2 = new ethers.Contract(tco2Address, tco2ABI, addr1);
       const balance = await tco2.balanceOf(addr1.address);
-      expect(formatEther(balance)).to.be.eql(
-        formatEther(parseEther("1.0").sub(fees))
-      );
+      expect(formatEther(balance)).to.be.eql(formatEther(ONE_ETHER.sub(fees)));
 
       expect(formatEther(await nct.balanceOf(addr1.address))).to.be.eql(
-        formatEther(nctBalanceBefore.sub(parseEther("1.0")))
+        formatEther(nctBalanceBefore.sub(ONE_ETHER))
       );
     });
 
@@ -168,9 +168,9 @@ describe("Testing Toucan-SDK contract interactions", function () {
       );
       const nctBalanceBefore = await nct.balanceOf(addr1.address);
 
-      await toucan.redeemAuto("NCT", parseEther("1.0"));
+      await toucan.redeemAuto("NCT", ONE_ETHER);
 
-      await toucan.depositTCO2("NCT", parseEther("1.0"), tco2.address);
+      await toucan.depositTCO2("NCT", ONE_ETHER, tco2.address);
 
       expect(formatEther(await tco2.balanceOf(addr1.address))).to.be.eql(
         formatEther(tco2BalanceBefore)
@@ -198,19 +198,17 @@ describe("Testing Toucan-SDK contract interactions", function () {
       const fees = await toucan.calculateRedeemFees(
         "BCT",
         [tco2Address],
-        [parseEther("1.0")]
+        [ONE_ETHER]
       );
 
-      await toucan.redeemMany("BCT", [tco2Address], [parseEther("1.0")]);
+      await toucan.redeemMany("BCT", [tco2Address], [ONE_ETHER]);
 
       const tco2 = new ethers.Contract(tco2Address, tco2ABI, addr1);
       const balance = await tco2.balanceOf(addr1.address);
-      expect(formatEther(balance)).to.be.eql(
-        formatEther(parseEther("1.0").sub(fees))
-      );
+      expect(formatEther(balance)).to.be.eql(formatEther(ONE_ETHER.sub(fees)));
 
       expect(formatEther(await bct.balanceOf(addr1.address))).to.be.eql(
-        formatEther(bctBalanceBefore.sub(parseEther("1.0")))
+        formatEther(bctBalanceBefore.sub(ONE_ETHER))
       );
     });
 
@@ -221,9 +219,9 @@ describe("Testing Toucan-SDK contract interactions", function () {
       const bct = toucan.getPoolContract("BCT");
       const bctBalanceBefore = await bct.balanceOf(addr1.address);
 
-      await toucan.redeemAuto("BCT", parseEther("1.0"));
+      await toucan.redeemAuto("BCT", ONE_ETHER);
 
-      await toucan.depositTCO2("BCT", parseEther("1.0"), TCO2.address);
+      await toucan.depositTCO2("BCT", ONE_ETHER, TCO2.address);
 
       expect(formatEther(await TCO2.balanceOf(addr1.address))).to.be.eql(
         formatEther(tco2BalanceBefore)
@@ -248,14 +246,14 @@ describe("Testing Toucan-SDK contract interactions", function () {
 
   describe("Testing TCO related methods", function () {
     it("Should retire 1 TCO2 & mint the certificate", async function () {
-      const tco2s = await toucan.redeemAuto2("NCT", parseEther("1.0"));
+      const tco2s = await toucan.redeemAuto2("NCT", ONE_ETHER);
 
       await toucan.retireAndMintCertificate(
         "Test",
         addr1.address,
         "Test",
         "Test Message",
-        parseEther("1.0"),
+        ONE_ETHER,
         tco2s[0].address
       );
 
@@ -263,10 +261,10 @@ describe("Testing Toucan-SDK contract interactions", function () {
     });
 
     it("Should retire 1 TCO2", async function () {
-      const tco2s = await toucan.redeemAuto2("NCT", parseEther("1.0"));
+      const tco2s = await toucan.redeemAuto2("NCT", ONE_ETHER);
 
       const retirementReceipt = await toucan.retire(
-        parseEther("1.0"),
+        ONE_ETHER,
         tco2s[0].address
       );
       const retiredEvents = retirementReceipt.events?.filter((event) => {
@@ -278,15 +276,15 @@ describe("Testing Toucan-SDK contract interactions", function () {
     });
 
     it("Should retire 1 TCO2 from another address", async function () {
-      const tco2s = await toucan.redeemAuto2("NCT", parseEther("1.0"));
+      const tco2s = await toucan.redeemAuto2("NCT", ONE_ETHER);
 
       const TCO2 = toucan.getTCO2Contract(tco2s[0].address);
-      await TCO2.approve(addr2.address, parseEther("1.0"));
+      await TCO2.approve(addr2.address, ONE_ETHER);
 
       const toucan2 = new ToucanClient("polygon");
       toucan2.setSigner(addr2);
 
-      await toucan2.retireFrom(parseEther("1.0"), addr1.address, TCO2.address);
+      await toucan2.retireFrom(ONE_ETHER, addr1.address, TCO2.address);
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -15,7 +15,7 @@ import { PoolSymbol } from "../dist/types";
 import { poolTokenABI, swapperABI, tco2ABI } from "../dist/utils/ABIs";
 import addresses from "../dist/utils/addresses";
 
-describe("Testing Toucan-SDK", function () {
+describe("Testing Toucan-SDK contract interactions", function () {
   let addr1: SignerWithAddress;
   let addr2: SignerWithAddress;
   let toucan: ToucanClient;
@@ -287,70 +287,6 @@ describe("Testing Toucan-SDK", function () {
       toucan2.setSigner(addr2);
 
       await toucan2.retireFrom(parseEther("1.0"), addr1.address, TCO2.address);
-    });
-  });
-
-  describe("Testing subgraph related methods", function () {
-    it("Should fetch user batches", async function () {
-      expect(await toucan.fetchUserBatches(addr1.address)).to.not.throw;
-    });
-
-    describe("Testing TCO2 Token fetching methods", function () {
-      it("Should fetch details about TCO2 based on its address", async function () {
-        expect(
-          await toucan.fetchTCO2TokenById(
-            "0x0044c5a5a6f626b673224a3c0d71e851ad3d5153"
-          )
-        ).to.not.throw;
-      });
-
-      it("Should fetch details about TCO2 based on its full symbol", async function () {
-        expect(await toucan.fetchTCO2TokenByFullSymbol("TCO2-VCS-1718-2013")).to
-          .not.throw;
-      });
-
-      it("Should fetch all TCO2 Tokens", async function () {
-        expect(await toucan.fetchAllTCO2Tokens()).to.not.throw;
-      });
-    });
-
-    it("Should fetch bridged batch tokens", async function () {
-      expect(await toucan.fetchBridgedBatchTokens()).to.not.throw;
-    });
-
-    it("Should fetch user retirements", async function () {
-      expect(await toucan.fetchUserRetirements(addr1.address)).to.not.throw;
-    });
-
-    describe("Testing Redeems fetching methods", function () {
-      it("Should fetch redeems", async function () {
-        expect(await toucan.fetchRedeems("NCT")).to.not.throw;
-      });
-
-      it("Should fetch user redeems", async function () {
-        expect(await toucan.fetchUserRedeems(addr1.address, "NCT")).to.not
-          .throw;
-      });
-    });
-
-    it("Should fetch pooled tokens", async function () {
-      expect(await toucan.fetchPoolContents("NCT")).to.not.throw;
-    });
-
-    it("Should fetch a project by its id", async function () {
-      expect(await toucan.fetchProjectById("1")).to.not.throw;
-    });
-
-    it("Should fetch aggregations", async function () {
-      expect(await toucan.fetchAggregations()).to.not.throw;
-    });
-
-    it("Should fetch price of BCT", async function () {
-      expect(await toucan.fetchTokenPriceOnSushiSwap("BCT")).to.not.throw;
-    });
-
-    it("Should fetch price of NCT", async function () {
-      expect(await toucan.fetchTokenPriceOnSushiSwap("NCT")).to.not.throw;
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -111,17 +111,15 @@ describe("Testing Toucan-SDK contract interactions", function () {
 
     it("Should automatically redeem NCT & return a correct array of TCO2s", async function () {
       const scoredTCO2s = await getFilteredScoredTCO2s("NCT");
-      const tco2 = new ethers.Contract(scoredTCO2s[0], tco2ABI, addr1);
-      const balanceBefore = await tco2.balanceOf(addr1.address);
+
+      const expectedTco2s: {
+        address: string;
+        amount: BigNumber;
+      }[] = [{ address: scoredTCO2s[0], amount: ONE_ETHER }];
 
       const tco2s = await toucan.redeemAuto2("NCT", ONE_ETHER);
 
-      for (let i = 0; i < tco2s.length; i++) {
-        const tco2 = new ethers.Contract(tco2s[i].address, tco2ABI, addr1);
-        expect(formatEther(await tco2.balanceOf(addr1.address))).to.be.eql(
-          formatEther((await tco2s[i].amount).add(balanceBefore))
-        );
-      }
+      expect(tco2s).to.be.eql(expectedTco2s);
     });
 
     it("Should selectively redeem NCT for the highest quality TCO2s", async function () {

--- a/test/subgraph.test.ts
+++ b/test/subgraph.test.ts
@@ -1,0 +1,77 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { ToucanClient } from "../dist";
+
+describe("Testing Toucan-SDK subgraph interactions", function () {
+  let addr1: SignerWithAddress;
+  let toucan: ToucanClient;
+
+  before(async () => {
+    [addr1] = await ethers.getSigners();
+    toucan = new ToucanClient("polygon");
+    toucan.setSigner(addr1);
+  });
+
+  it("Should fetch user batches", async function () {
+    expect(await toucan.fetchUserBatches(addr1.address)).to.not.throw;
+  });
+
+  describe("Testing TCO2 Token fetching methods", function () {
+    it("Should fetch details about TCO2 based on its address", async function () {
+      expect(
+        await toucan.fetchTCO2TokenById(
+          "0x0044c5a5a6f626b673224a3c0d71e851ad3d5153"
+        )
+      ).to.not.throw;
+    });
+
+    it("Should fetch details about TCO2 based on its full symbol", async function () {
+      expect(await toucan.fetchTCO2TokenByFullSymbol("TCO2-VCS-1718-2013")).to
+        .not.throw;
+    });
+
+    it("Should fetch all TCO2 Tokens", async function () {
+      expect(await toucan.fetchAllTCO2Tokens()).to.not.throw;
+    });
+  });
+
+  it("Should fetch bridged batch tokens", async function () {
+    expect(await toucan.fetchBridgedBatchTokens()).to.not.throw;
+  });
+
+  it("Should fetch user retirements", async function () {
+    expect(await toucan.fetchUserRetirements(addr1.address)).to.not.throw;
+  });
+
+  describe("Testing Redeems fetching methods", function () {
+    it("Should fetch redeems", async function () {
+      expect(await toucan.fetchRedeems("NCT")).to.not.throw;
+    });
+
+    it("Should fetch user redeems", async function () {
+      expect(await toucan.fetchUserRedeems(addr1.address, "NCT")).to.not.throw;
+    });
+  });
+
+  it("Should fetch pooled tokens", async function () {
+    expect(await toucan.fetchPoolContents("NCT")).to.not.throw;
+  });
+
+  it("Should fetch a project by its id", async function () {
+    expect(await toucan.fetchProjectById("1")).to.not.throw;
+  });
+
+  it("Should fetch aggregations", async function () {
+    expect(await toucan.fetchAggregations()).to.not.throw;
+  });
+
+  it("Should fetch price of BCT", async function () {
+    expect(await toucan.fetchTokenPriceOnSushiSwap("BCT")).to.not.throw;
+  });
+
+  it("Should fetch price of NCT", async function () {
+    expect(await toucan.fetchTokenPriceOnSushiSwap("NCT")).to.not.throw;
+  });
+});


### PR DESCRIPTION
# Why?

I noticed there were some tests that were failing. These tests were failing because of external changes:
- contracts were upgraded
- some scored TCO2s had a 0 balance in the pools

# What?

To fix these issues I have:
- updated ABIs
- created a method to filter 0 balance scored TCO2s
- created a method for a dynamic redeem amount

Also, some refactoring alongside the above:
- add `formatEther` on hex values so they're readable when logged
- remove`.not.be.reverted` so details are logged when error is reverted
- separate subgraph tests from contract tests
- replace `parseEther("1.0")` with constant

