### PR TITLE
[BLU-2623] NPM publish latest version of the sdk

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - run: yarn
+      - run: yarn build:clean
       - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,38 @@ on:
   release:
     types: [published]
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install packages
+        run: yarn
+
+      - name: Compile code
+        run: yarn build:clean
+
+      - name: Format
+        run: yarn format:check
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Test
+        run: yarn test
+
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I took inspiration from other SDKs / packages to figure out what could be causing our users to have build issues. I believe these changes to the CI will make the package be properly published by the CI and as such allow users to use the SDK.

**Note:** CI fails on the OffsetHelper tests because of an issue specific to the OffsetHelper. I am working on it with an external contributor. It should be fixed soon and it shouldn't stop this PR.