### PR TITLE
chore: disable offset helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "0.1.5-beta",
+  "version": "0.1.6-beta",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/subclasses/ContractInteractions.ts
+++ b/src/subclasses/ContractInteractions.ts
@@ -33,7 +33,6 @@ import {
 import { Network, PoolSymbol } from "../types";
 import { GAS_LIMIT } from "../utils";
 import {
-  offsetHelperABI,
   poolTokenABI,
   tco2ABI,
   toucanContractRegistryABI,
@@ -638,12 +637,7 @@ class ContractInteractions {
   public getOffsetHelperContract = (
     signerOrProvider: ethers.Signer | ethers.providers.Provider
   ): OffsetHelper => {
-    const offsetHelper = new ethers.Contract(
-      this.addresses.offsetHelper,
-      offsetHelperABI,
-      signerOrProvider
-    ) as OffsetHelper;
-    return offsetHelper;
+    throw new Error("OffsetHelper is not supported yet");
   };
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -99,7 +99,7 @@ describe("Testing Toucan-SDK contract interactions", function () {
     });
   });
 
-  describe("Testing OffsetHelper related methods", function () {
+  describe.skip("Testing OffsetHelper related methods", function () {
     it("Should retire 1 TCO2 using pool token deposit", async function () {
       const pool = await toucan.getPoolContract("NCT");
 


### PR DESCRIPTION
We introduced new functionality & fixed bugs in the OffsetHelper. These resulted in changed ABIs / function names.

The above ends up creating errors when the SDK interacts with the OffsetHelper. We would need to adapt the SDK to these changes but right now this is not a priority, so I'm disabling the SDK's interactions with it temporarily. 

An [issue to track the work of re-integrating the OffsetHelper <> SDK has been made here](https://linear.app/toucan/issue/BLU-3483/adapt-sdk-to-new-offsethelper).