### PR TITLE
Dvx 6/fix type export issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ _Full documentation coming soon._
 ## Install
 
 ```
-npm i toucan-sdk@1.0.0-beta
+npm i toucan-sdk
 ```
 
 or
 
 ```
-yarn add toucan-sdk@1.0.0-beta
+yarn add toucan-sdk
 ```
 
 # Quickstart

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ yarn add toucan-sdk
 Instantiate the ToucanClient and set a signer & provider to interact with our infrastructure.
 
 ```typescript
-import { ToucanClient } from "toucan-sdk";
+import ToucanClient from "toucan-sdk";
 
 const toucan = new ToucanClient("alfajores", provider, signer);
 ```
@@ -33,7 +33,7 @@ const toucan = new ToucanClient("alfajores", provider, signer);
 You could also set the signer/provider later if you prefer that. They are optional. But you will need to set them if you want to interact with contracts. The provider is read-only, while the signer allows both writing to and reading from the blockchain.
 
 ```typescript
-import { ToucanClient } from "toucan-sdk";
+import ToucanClient from "toucan-sdk";
 
 const toucan = new ToucanClient("alfajores");
 toucan.setProvider(provider);

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ _Full documentation coming soon._
 ## Install
 
 ```
-npm i toucan-sdk
+npm i toucan-sdk@1.0.0-beta
 ```
 
 or
 
 ```
-yarn add toucan-sdk
+yarn add toucan-sdk@1.0.0-beta
 ```
 
 # Quickstart

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "1.0.0-beta",
+  "version": "1.0.1-beta",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "1.0.3-beta",
+  "version": "1.0.4-beta",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "1.0.1-beta",
+  "version": "1.0.2-beta",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "1.0.2-beta",
+  "version": "1.0.3-beta",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,16 @@ import {
   UserRedeemsMethod,
   UserRetirementsMethod,
 } from "./types/methods";
-export * from "./types/responses";
+export {
+  UserBatchesResponse,
+  TCO2TokenResponse,
+  BridgedBatchTokensResponse,
+  UserRetirementsResponse,
+  RedeemsResponse,
+  PoolContentsResponse,
+  ProjectResponse,
+  BalanceResponse
+} from "./types/responses";
 
 /**
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,16 +43,7 @@ import {
   UserRedeemsMethod,
   UserRetirementsMethod,
 } from "./types/methods";
-export {
-  UserBatchesResponse,
-  TCO2TokenResponse,
-  BridgedBatchTokensResponse,
-  UserRetirementsResponse,
-  RedeemsResponse,
-  PoolContentsResponse,
-  ProjectResponse,
-  BalanceResponse
-} from "./types/responses";
+
 
 /**
  *
@@ -772,3 +763,16 @@ export default class ToucanClient {
     return this.contractInteractions.getOffsetHelperContract(signerOrProvider);
   };
 }
+
+
+
+export {
+  UserBatchesResponse,
+  TCO2TokenResponse,
+  BridgedBatchTokensResponse,
+  UserRetirementsResponse,
+  RedeemsResponse,
+  PoolContentsResponse,
+  ProjectResponse,
+  BalanceResponse
+} from "./types/responses";

--- a/src/index.ts
+++ b/src/index.ts
@@ -766,13 +766,4 @@ export default class ToucanClient {
 
 
 
-export {
-  UserBatchesResponse,
-  TCO2TokenResponse,
-  BridgedBatchTokensResponse,
-  UserRetirementsResponse,
-  RedeemsResponse,
-  PoolContentsResponse,
-  ProjectResponse,
-  BalanceResponse
-} from "./types/responses";
+export * from "./types/responses";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,20 @@
 /**
-  The OffsetHelper's purpose is to simplify the carbon offsetting process.
-  Copyright (C) 2022  Toucan Labs
+The OffsetHelper's purpose is to simplify the carbon offsetting process.
+Copyright (C) 2022  Toucan Labs
 
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 
 import "isomorphic-unfetch";
 
@@ -43,7 +43,6 @@ import {
   UserRedeemsMethod,
   UserRetirementsMethod,
 } from "./types/methods";
-
 
 /**
  *
@@ -763,6 +762,5 @@ export default class ToucanClient {
     return this.contractInteractions.getOffsetHelperContract(signerOrProvider);
   };
 }
-
 
 export * from "./types/responses";

--- a/src/index.ts
+++ b/src/index.ts
@@ -765,5 +765,4 @@ export default class ToucanClient {
 }
 
 
-
 export * from "./types/responses";


### PR DESCRIPTION
Fix: We have updated types from `fetchUserRetirementsResult` to `UserRetirementsResponse` , but when developing with it, I am still getting old types proposed, even though in npm it shows me the newest version without the same type, same as the main branch. 

