### PR TITLE
Add editor ignore section to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ cache
 # DS Store
 *./DS_Store
 .DS_Store
+
+# Editor files
+tags


### PR DESCRIPTION
Some vim plugins like Gutentags
(https://github.com/ludovicchabant/vim-gutentags) write `tags` files into the project directory to keep track of symbols.

This file needs to be ignored by git because it should never be committed.