### PR TITLE
Fix a few mistakes in the README file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ cache
 # DS Store
 *./DS_Store
 .DS_Store
+
+# Editor files
+tags

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ If you do, that's also quite easy to pull off. You just replace the usage of the
 ```typescript
 const retirementReceipt = await toucan.retireAndMintCertificate(
   "Alice",
-  signer.address,
+  bobsAddress,
   "Bob",
   "Just helping the planet",
   parseEther("3.0"),
@@ -318,8 +318,6 @@ const retirementReceipt = await toucan.retireAndMintCertificate(
 );
 ```
 
-Why do you see my name twice you ask? 🤔
-
-Well, the first "Alice" represents the entity that is doing the retirement/offset. The second one represents the party that 'benefits' from it, in this case "Bob". We will also add Bob's address so now the relation of the certificate is set to that address instead of the retiring party.
+"Alice" represents the entity that is doing the retirement/offset. The second name represents the party that 'benefits' from it, in this case "Bob". We will also add Bob's address so now the relation of the certificate is set to that address instead of the retiring party.
 
 This useful in case you happen to be an entity that retires on behalf of someone else.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ yarn add toucan-sdk
 Instantiate the ToucanClient and set a `signer` & `provider` to interact with our infrastructure.
 
 ```typescript
-import { ToucanClient } from "toucan-sdk";
+import ToucanClient from "toucan-sdk";
 
 const toucan = new ToucanClient("alfajores", provider, signer);
 ```
@@ -37,7 +37,7 @@ const toucan = new ToucanClient("alfajores", provider, signer);
 You could also set the signer/provider later if you prefer that. They are optional. But you will need to set them if you want to interact with contracts. The provider is read-only, while the signer allows both writing to and reading from the blockchain.
 
 ```typescript
-import { ToucanClient } from "toucan-sdk";
+import ToucanClient from "toucan-sdk";
 
 const toucan = new ToucanClient("alfajores");
 toucan.setProvider(provider);
@@ -140,7 +140,7 @@ Now you have quite some info on the project, including its address.
 Toucan SDK offers a lot of pre-defined queries. Try them out!
 
 ```typescript
-import { ToucanClient } from "toucan-sdk";
+import ToucanClient from "toucan-sdk";
 
 // here we don't need to set the signer or provider
 const toucan = new ToucanClient("alfajores");
@@ -186,7 +186,7 @@ This allows you to fetch with your own queries and can be very powerful if you k
 
 ```typescript
 import { gql } from "@urql/core";
-import { ToucanClient } from "toucan-sdk";
+import ToucanClient from "toucan-sdk";
 
 const toucan = new ToucanClient("alfajores");
 


### PR DESCRIPTION
The docs showed that `ToucanClient` is a named export which it isn't.
It's a default export, thus the correct way to import the libary is like so:

```
import ToucanClient from 'toucan-sdk';
```

Please review the `.gitignore` change #102 before this one.

I added another commit because it was also pertaining to the docs but the branch name is a bit out of date now.