### PR TITLE
Replace Subgraph urls

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export type Network = "polygon" | "mumbai" | "celo" | "alfajores";
+export type Network = "polygon" | "celo" | "alfajores";
 
 export type PoolSymbol = "BCT" | "NCT";
 

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -11,7 +11,6 @@ export interface INetworkAddresses {
   celo: INetworkTokenAddresses;
   alfajores: INetworkTokenAddresses;
   polygon: INetworkTokenAddresses;
-  mumbai: INetworkTokenAddresses;
 }
 
 const addresses: INetworkAddresses = {
@@ -38,14 +37,6 @@ const addresses: INetworkAddresses = {
     swapper: "0xfca57EE8B62d8e4b9792bd68095c2520723c306d",
     weth: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
     toucanContractRegistry: "0x263fa1c180889b3a3f46330f32a4a23287e99fc9",
-  },
-  mumbai: {
-    bct: "0xf2438a14f668b1bba53408346288f3d7c71c10a1",
-    nct: "0x7becba11618ca63ead5605de235f6dd3b25c530e",
-    offsetHelper: "0x66B1B59F9D59413dDC1539122D7d5F6b70869717",
-    swapper: "0x68DF99A11BD292cB91d3Fb07272062eF339d6dc1",
-    weth: "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
-    toucanContractRegistry: "0x6739d490670b2710dc7e79bb12e455de33ee1cb6",
   },
 };
 

--- a/src/utils/graphAPIs.ts
+++ b/src/utils/graphAPIs.ts
@@ -1,12 +1,17 @@
+// Description: This file contains the API URLs for the subgraphs used in the project.
+// Links are sourced from https://docs.toucan.earth/developers/sdk/subgraph
+
 export const CELO_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/celo";
+  "https://gateway-arbitrum.network.thegraph.com/api/259c8584572d055a1c09d3ecca462dd2/subgraphs/id/BWmN569zDopYXp3nzDukJsGDHqRstYAFULFPH8rxyVBk";
 export const ALFAJORES_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/alfajores";
+  "https://gateway-arbitrum.network.thegraph.com/api/259c8584572d055a1c09d3ecca462dd2/subgraphs/id/4uY2L3vQW8XKYPrFFk4i6ZuJkgbpJ8SbJayc8wzMBRYw";
 export const POLYGON_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/matic";
-export const MUMBAI_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/mumbai";
+  "https://gateway-arbitrum.network.thegraph.com/api/259c8584572d055a1c09d3ecca462dd2/subgraphs/id/FU5APMSSCqcRy9jy56aXJiGV3PQmFQHg2tzukvSJBgwW";
 export const POLYGON_SUSHI_GRAPH_API_URL =
   "https://api.thegraph.com/subgraphs/name/sushiswap/matic-exchange";
 export const CELO_UBESWAP_GRAPH_API_URL =
   "https://api.thegraph.com/subgraphs/name/ubeswap/ubeswap";
+export const BASE_TOUCAN_GRAPH_API_URL =
+  "https://gateway-arbitrum.network.thegraph.com/api/259c8584572d055a1c09d3ecca462dd2/subgraphs/id/AEJ5PEDye6Z198HRQBioG6mZ6ZacHenBg2HTopZPsUCi";
+export const BASE_SEPOLIA_GRAPH_API_URL =
+  "https://gateway-arbitrum.network.thegraph.com/api/259c8584572d055a1c09d3ecca462dd2/subgraphs/id/2oKCq3rDwdYPSao4UbDZKSNbawEdhBVf3BxmqJzFe1uj";

--- a/src/utils/graphClients.ts
+++ b/src/utils/graphClients.ts
@@ -5,7 +5,6 @@ import {
   ALFAJORES_TOUCAN_GRAPH_API_URL,
   CELO_TOUCAN_GRAPH_API_URL,
   CELO_UBESWAP_GRAPH_API_URL,
-  MUMBAI_TOUCAN_GRAPH_API_URL,
   POLYGON_SUSHI_GRAPH_API_URL,
   POLYGON_TOUCAN_GRAPH_API_URL,
 } from "./graphAPIs";
@@ -15,8 +14,6 @@ export const getToucanGraphClient = (network: Network) =>
     url:
       network === "polygon"
         ? POLYGON_TOUCAN_GRAPH_API_URL
-        : network === "mumbai"
-        ? MUMBAI_TOUCAN_GRAPH_API_URL
         : network === "celo"
         ? CELO_TOUCAN_GRAPH_API_URL
         : ALFAJORES_TOUCAN_GRAPH_API_URL,
@@ -28,7 +25,7 @@ export const getToucanGraphClient = (network: Network) =>
 export const getDexGraphClient = (network: Network) =>
   createClient({
     url:
-      network === "polygon" || network === "mumbai"
+      network === "polygon"
         ? POLYGON_SUSHI_GRAPH_API_URL
         : CELO_UBESWAP_GRAPH_API_URL,
     exchanges: [cacheExchange, fetchExchange],


### PR DESCRIPTION
Replace Subgraph urls with new ones sourced from https://docs.toucan.earth/developers/sdk/subgraph.
Removed obsolete mumbai subgraph