### PR TITLE
Replace Subgraph urls with new ones sourced from docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ NODE_PROVIDER_MUMBAI_RPC_URL=https://rpc.ankr.com/polygon_mumbai
 NODE_PROVIDER_CELO_RPC_URL=https://rpc.ankr.com/celo
 NODE_PROVIDER_ALFAJORES_RPC_URL=https://alfajores-forno.celo-testnet.org
 TEST_TIMEOUT=500000
+GRAPH_API_KEY=...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  GRAPH_API_KEY: 0e7dd738749485cb3dceaeaa33ce3eb8
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -213,7 +213,14 @@ await toucan.fetchAggregations();
 
 Now that you have an overview of our pre-build queries, let's have a look at the `fetchCustomQuery` method.
 
-This allows you to fetch with your own queries and can be very powerful if you know graphQL. You can also check out a lot of example queries in our subgraph [playgrounds](https://thegraph.com/hosted-service/subgraph/toucanprotocol/matic).
+This allows you to fetch with your own queries and can be very powerful if you know graphQL. You can also check out a lot of example queries in our Subgraph playgrounds:
+
+- [Matic](https://thegraph.com/explorer/subgraphs/FU5APMSSCqcRy9jy56aXJiGV3PQmFQHg2tzukvSJBgwW)
+- [Celo](https://thegraph.com/explorer/subgraphs/BWmN569zDopYXp3nzDukJsGDHqRstYAFULFPH8rxyVBk)
+- [Base](https://thegraph.com/explorer/subgraphs/AEJ5PEDye6Z198HRQBioG6mZ6ZacHenBg2HTopZPsUCi)
+- [Alfajores](https://thegraph.com/explorer/subgraphs/4uY2L3vQW8XKYPrFFk4i6ZuJkgbpJ8SbJayc8wzMBRYw)
+- [Base Sepolia](https://thegraph.com/explorer/subgraphs/2oKCq3rDwdYPSao4UbDZKSNbawEdhBVf3BxmqJzFe1uj)
+- [Amoy](https://thegraph.com/explorer/subgraphs/FKzFZuYHxyHiiDmdW9Qvwtet1Ad1ERsvjWMhhqd9V8pk)
 
 - Getting all infos on a carbon project (`region` stands for the country)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For the full documentation, check our [docs](https://docs.toucan.earth/toucan/de
 
 ⚠️ This SDK is heavily under development. USE AT YOUR OWN RISK. ⚠️
 
-## Install
+## Install and setup
 
 ```
 npm i toucan-sdk
@@ -21,6 +21,10 @@ or
 ```
 yarn add toucan-sdk
 ```
+
+Now, copy `.env.example` to `.env`.
+
+Before you can make Subgraph queries, you need to set `GRAPH_API_KEY` in your `.env` file. You can create an API key in [The Graph Studio](https://thegraph.com/studio/apikeys/) after connecting your wallet.
 
 # Quickstart
 
@@ -161,7 +165,7 @@ The result will look like this:
 
 Now you have quite some info on the project, including its address.
 
-## All queries:
+## All queries
 
 Toucan SDK offers a lot of pre-defined queries. Try them out!
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ If you don't have a signer nor a provider set, you can only interact with the su
 
 ## Fetch pool prices from a Dex
 
+IMPORTANT:
+_Fetching pool prices is currently not working. We are working on a fix for this._
+
 You can find pools for Toucan pool tokens on [Celo Network](https://celo.org) at [Uniswap](https://uniswap.org/) and for [Polygon Network](https://polygon.technology) on [SushiSwap](sushi.com).
 
 Something that may come in handy in your applications is fetching the USD price of our pool tokens.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-sdk",
-  "version": "1.0.5-beta",
+  "version": "1.0.6-beta",
   "description": "A JavaScript SDK for Toucan Protocol. Works in the web browser and Node.js.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -830,6 +830,9 @@ export default class ToucanClient {
   // --------------------------------------------------------------------------------
   // --------------------------------------------------------------------------------
 
+  // FIXME: The SushiSwap and Ubeswap Subgraph APIs that are used to get token
+  // market prices have changed slightly. This function breaks currently. Work
+  // on it is tracked in LILA-7487.
   fetchTokenPriceOnDex = async (
     pool: PoolSymbol
   ): Promise<{

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export type Network = "polygon" | "mumbai" | "celo" | "alfajores";
+export type Network = "polygon" | "celo" | "alfajores";
 
 export type PoolSymbol = "BCT" | "NCT";
 

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -11,7 +11,6 @@ export interface INetworkAddresses {
   celo: INetworkTokenAddresses;
   alfajores: INetworkTokenAddresses;
   polygon: INetworkTokenAddresses;
-  mumbai: INetworkTokenAddresses;
 }
 
 const addresses: INetworkAddresses = {
@@ -38,14 +37,6 @@ const addresses: INetworkAddresses = {
     swapper: "0xfca57EE8B62d8e4b9792bd68095c2520723c306d",
     weth: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
     toucanContractRegistry: "0x263fa1c180889b3a3f46330f32a4a23287e99fc9",
-  },
-  mumbai: {
-    bct: "0xf2438a14f668b1bba53408346288f3d7c71c10a1",
-    nct: "0x7becba11618ca63ead5605de235f6dd3b25c530e",
-    offsetHelper: "0x66B1B59F9D59413dDC1539122D7d5F6b70869717",
-    swapper: "0x68DF99A11BD292cB91d3Fb07272062eF339d6dc1",
-    weth: "0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa",
-    toucanContractRegistry: "0x6739d490670b2710dc7e79bb12e455de33ee1cb6",
   },
 };
 

--- a/src/utils/graphAPIs.ts
+++ b/src/utils/graphAPIs.ts
@@ -1,17 +1,14 @@
 // Description: This file contains the API URLs for the subgraphs used in the project.
 // Links are sourced from https://docs.toucan.earth/developers/sdk/subgraph
 
-export const CELO_TOUCAN_GRAPH_API_URL =
-  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/BWmN569zDopYXp3nzDukJsGDHqRstYAFULFPH8rxyVBk";
-export const ALFAJORES_TOUCAN_GRAPH_API_URL =
-  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/4uY2L3vQW8XKYPrFFk4i6ZuJkgbpJ8SbJayc8wzMBRYw";
-export const POLYGON_TOUCAN_GRAPH_API_URL =
-  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/FU5APMSSCqcRy9jy56aXJiGV3PQmFQHg2tzukvSJBgwW";
+const { GRAPH_API_KEY } = process.env;
+
+export const CELO_TOUCAN_GRAPH_API_URL = `https://gateway-arbitrum.network.thegraph.com/api/${GRAPH_API_KEY}/subgraphs/id/BWmN569zDopYXp3nzDukJsGDHqRstYAFULFPH8rxyVBk`;
+export const ALFAJORES_TOUCAN_GRAPH_API_URL = `https://gateway-arbitrum.network.thegraph.com/api/${GRAPH_API_KEY}/subgraphs/id/4uY2L3vQW8XKYPrFFk4i6ZuJkgbpJ8SbJayc8wzMBRYw`;
+export const POLYGON_TOUCAN_GRAPH_API_URL = `https://gateway-arbitrum.network.thegraph.com/api/${GRAPH_API_KEY}/subgraphs/id/FU5APMSSCqcRy9jy56aXJiGV3PQmFQHg2tzukvSJBgwW`;
 export const POLYGON_SUSHI_GRAPH_API_URL =
   "https://api.thegraph.com/subgraphs/name/sushiswap/matic-exchange";
 export const CELO_UBESWAP_GRAPH_API_URL =
   "https://api.thegraph.com/subgraphs/name/ubeswap/ubeswap";
-export const BASE_TOUCAN_GRAPH_API_URL =
-  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/AEJ5PEDye6Z198HRQBioG6mZ6ZacHenBg2HTopZPsUCi";
-export const BASE_SEPOLIA_GRAPH_API_URL =
-  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/2oKCq3rDwdYPSao4UbDZKSNbawEdhBVf3BxmqJzFe1uj";
+export const BASE_TOUCAN_GRAPH_API_URL = `https://gateway-arbitrum.network.thegraph.com/api/${GRAPH_API_KEY}/subgraphs/id/AEJ5PEDye6Z198HRQBioG6mZ6ZacHenBg2HTopZPsUCi`;
+export const BASE_SEPOLIA_GRAPH_API_URL = `https://gateway-arbitrum.network.thegraph.com/api/${GRAPH_API_KEY}/subgraphs/id/2oKCq3rDwdYPSao4UbDZKSNbawEdhBVf3BxmqJzFe1uj`;

--- a/src/utils/graphAPIs.ts
+++ b/src/utils/graphAPIs.ts
@@ -1,12 +1,17 @@
+// Description: This file contains the API URLs for the subgraphs used in the project.
+// Links are sourced from https://docs.toucan.earth/developers/sdk/subgraph
+
 export const CELO_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/celo";
+  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/BWmN569zDopYXp3nzDukJsGDHqRstYAFULFPH8rxyVBk";
 export const ALFAJORES_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/alfajores";
+  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/4uY2L3vQW8XKYPrFFk4i6ZuJkgbpJ8SbJayc8wzMBRYw";
 export const POLYGON_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/matic";
-export const MUMBAI_TOUCAN_GRAPH_API_URL =
-  "https://api.thegraph.com/subgraphs/name/toucanprotocol/mumbai";
+  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/FU5APMSSCqcRy9jy56aXJiGV3PQmFQHg2tzukvSJBgwW";
 export const POLYGON_SUSHI_GRAPH_API_URL =
   "https://api.thegraph.com/subgraphs/name/sushiswap/matic-exchange";
 export const CELO_UBESWAP_GRAPH_API_URL =
   "https://api.thegraph.com/subgraphs/name/ubeswap/ubeswap";
+export const BASE_TOUCAN_GRAPH_API_URL =
+  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/AEJ5PEDye6Z198HRQBioG6mZ6ZacHenBg2HTopZPsUCi";
+export const BASE_SEPOLIA_GRAPH_API_URL =
+  "https://gateway-arbitrum.network.thegraph.com/api/[api-key]/subgraphs/id/2oKCq3rDwdYPSao4UbDZKSNbawEdhBVf3BxmqJzFe1uj";

--- a/src/utils/graphClients.ts
+++ b/src/utils/graphClients.ts
@@ -5,7 +5,6 @@ import {
   ALFAJORES_TOUCAN_GRAPH_API_URL,
   CELO_TOUCAN_GRAPH_API_URL,
   CELO_UBESWAP_GRAPH_API_URL,
-  MUMBAI_TOUCAN_GRAPH_API_URL,
   POLYGON_SUSHI_GRAPH_API_URL,
   POLYGON_TOUCAN_GRAPH_API_URL,
 } from "./graphAPIs";
@@ -15,8 +14,6 @@ export const getToucanGraphClient = (network: Network) =>
     url:
       network === "polygon"
         ? POLYGON_TOUCAN_GRAPH_API_URL
-        : network === "mumbai"
-        ? MUMBAI_TOUCAN_GRAPH_API_URL
         : network === "celo"
         ? CELO_TOUCAN_GRAPH_API_URL
         : ALFAJORES_TOUCAN_GRAPH_API_URL,
@@ -28,7 +25,7 @@ export const getToucanGraphClient = (network: Network) =>
 export const getDexGraphClient = (network: Network) =>
   createClient({
     url:
-      network === "polygon" || network === "mumbai"
+      network === "polygon"
         ? POLYGON_SUSHI_GRAPH_API_URL
         : CELO_UBESWAP_GRAPH_API_URL,
     exchanges: [cacheExchange, fetchExchange],

--- a/test/subgraph.test.ts
+++ b/test/subgraph.test.ts
@@ -67,11 +67,11 @@ describe("Testing Toucan-SDK subgraph interactions", function () {
     expect(await toucan.fetchAggregations()).to.not.throw;
   });
 
-  it("Should fetch price of BCT", async function () {
+  xit("Should fetch price of BCT", async function () {
     expect(await toucan.fetchTokenPriceOnDex("BCT")).to.not.throw;
   });
 
-  it("Should fetch price of NCT", async function () {
+  xit("Should fetch price of NCT", async function () {
     expect(await toucan.fetchTokenPriceOnDex("NCT")).to.not.throw;
   });
 });


### PR DESCRIPTION
Taken from:
https://docs.toucan.earth/developers/sdk/subgraph.

This PR (original under #112) was kindly opened by @dankelleher. I just removed the API keys as we've decided to not expose them and get everybody to use their own.