### PR TITLE
chore: define expected package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
     "ts-node": "^10.1.0",
     "typechain": "^8.0.0",
     "typescript": "^4.5.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
For some reason, this seems to be always generated now every time I run yarn in the repo so we may as well set it.

https://nodejs.org/api/packages.html#packagemanager